### PR TITLE
package.json の config 内で原稿ディレクトリを指定可能にする

### DIFF
--- a/lib/FileReader.js
+++ b/lib/FileReader.js
@@ -1,7 +1,7 @@
 'use strict';
 const fs = require('fs-extra');
 const path = require('path');
-const episodesDir = 'episodes';
+const episodesDir = process.env.npm_package_config_episodes_dir || 'episodes';
 
 module.exports = class FileReader {
 

--- a/lib/Proofreader.js
+++ b/lib/Proofreader.js
@@ -1,7 +1,7 @@
 'use strict';
 const fs = require('fs-extra');
 const path = require('path');
-const episodesDir = 'episodes';
+const episodesDir = process.env.npm_package_config_episodes_dir || 'episodes';
 
 module.exports = class Proofreader {
 


### PR DESCRIPTION
## 提案
package.json の config 内で原稿ディレクトリを指定可能にする。

```package.json
    "config": {
        "episodes_dir": "source"
    },
```
無指定の場合、`episodes` ディレクトリが指定される。

## 現状

原稿を格納するディレクトリは `episodes` ディレクトリに固定

関連 #1 